### PR TITLE
Adding header search paths to support app archving

### DIFF
--- a/SalesforceNetworkSDK.xcodeproj/project.pbxproj
+++ b/SalesforceNetworkSDK.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(BUILT_PRODUCTS_DIR)/Headers",
+					"$(TARGET_BUILD_DIR)/Headers",
 					"$(SRCROOT)/dependencies/**",
 				);
 				INSTALL_PATH = /;
@@ -297,6 +298,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(BUILT_PRODUCTS_DIR)/Headers",
+					"$(TARGET_BUILD_DIR)/Headers",
 					"$(SRCROOT)/dependencies/**",
 				);
 				INSTALL_PATH = /;
@@ -330,7 +332,7 @@
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -351,7 +353,7 @@
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = NO;
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Adding header search paths for app archiving, which are different than the standard build path.  See [Issue 543](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/543) in the Mobile SDK repo.
