### PR TITLE
Pass the original API error(s) along in the event of a REST request failure

### DIFF
--- a/SalesforceNetworkSDK/SFNetworkOperation.m
+++ b/SalesforceNetworkSDK/SFNetworkOperation.m
@@ -519,7 +519,7 @@ static NSInteger const kFailedWithServerReturnedErrorCode = 999;
     
     id jsonResponse = [self responseAsJSON];
     if (jsonResponse && [jsonResponse isKindOfClass:[NSArray class]]) {
-        if ([jsonResponse count] == 1) {
+        if ([jsonResponse count] > 0) {
             id potentialError = [jsonResponse objectAtIndex:0];
             if ([potentialError isKindOfClass:[NSDictionary class]]) {
                 NSDictionary *errorDictionary = (NSDictionary *)potentialError;
@@ -528,7 +528,8 @@ static NSInteger const kFailedWithServerReturnedErrorCode = 999;
                 if (nil != potentialErrorCode && nil != potentialErrorMessage) {
                     NSDictionary *errorDictionary = @{
                                                       NSLocalizedDescriptionKey : potentialErrorMessage,
-                                                      NSLocalizedFailureReasonErrorKey : potentialErrorCode };
+                                                      NSLocalizedFailureReasonErrorKey : potentialErrorCode,
+                                                      kSFOriginalApiError : jsonResponse };
                     NSError *translatedError = [NSError errorWithDomain:error.domain code:error.code userInfo:errorDictionary];
                     return translatedError;
                 }

--- a/SalesforceNetworkSDK/SFNetworkUtils.h
+++ b/SalesforceNetworkSDK/SFNetworkUtils.h
@@ -36,6 +36,7 @@ typedef enum {
 
 extern NSString * const kErrorCodeKeyInResponse;
 extern NSString * const kErrorMessageKeyInResponse;
+extern NSString * const kSFOriginalApiError;
 
 /** Helper class for SFNetworkSDK 
  

--- a/SalesforceNetworkSDK/SFNetworkUtils.m
+++ b/SalesforceNetworkSDK/SFNetworkUtils.m
@@ -10,6 +10,7 @@
 
 NSString * const kErrorCodeKeyInResponse = @"errorCode";
 NSString * const kErrorMessageKeyInResponse = @"message";
+NSString * const kSFOriginalApiError = @"SFOriginalApiError";
 
 NSString * const kInvalidSessionID = @"INVALID_SESSION_ID";
 


### PR DESCRIPTION
Addresses Mobile SDK [Issue 521](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/521) and [Issue 703](https://github.com/forcedotcom/SalesforceMobileSDK-iOS/issues/703).
